### PR TITLE
A better way: fix compiler warnings by adding 'else' return value

### DIFF
--- a/src/Core/Scene/Scene.cpp
+++ b/src/Core/Scene/Scene.cpp
@@ -493,8 +493,7 @@ namespace obe::Scene
     void Scene::removeGameObject(const std::string& id)
     {
         m_gameObjectArray.erase(std::remove_if(m_gameObjectArray.begin(), m_gameObjectArray.end(), [&id](const std::unique_ptr<Script::GameObject>& ptr){
-            if (ptr->getId() == id)
-                return true;
+            return (ptr->getId() == id);
         }), m_gameObjectArray.end());
     }
 

--- a/src/Core/System/Window.cpp
+++ b/src/Core/System/Window.cpp
@@ -152,7 +152,7 @@ namespace obe::System
         if (!m_docked)
             return m_window.getSize();
         else
-            m_surface.getSize();
+            return m_surface.getSize();
     }
 
     bool Window::isOpen() const


### PR DESCRIPTION
A better way to fix it

original pull request:
[https://github.com/Sygmei/ObEngine/pull/181](https://github.com/Sygmei/ObEngine/pull/181)