### PR TITLE
Closes #271 - Add CollisionData struct

### DIFF
--- a/include/Core/Bindings/Collision/Collision.hpp
+++ b/include/Core/Bindings/Collision/Collision.hpp
@@ -10,4 +10,5 @@ namespace obe::Collision::Bindings
     void LoadClassTrajectory(sol::state_view state);
     void LoadClassTrajectoryNode(sol::state_view state);
     void LoadEnumColliderTagType(sol::state_view state);
+    void LoadStructCollisionData(sol::state_view state);
 };

--- a/include/Core/Collision/PolygonalCollider.hpp
+++ b/include/Core/Collision/PolygonalCollider.hpp
@@ -30,6 +30,19 @@ namespace obe::Collision
         Rejected
     };
 
+    class PolygonalCollider;
+    /**
+    * \brief Struct containing data of a collision applied to a collider
+    * \bind{CollisionData}
+    */
+    struct CollisionData
+    {
+        // Colliders the collider touched during the collision (empty if no collision occurs)
+        std::vector<PolygonalCollider*> colliders;
+        // Maximum distance that can be travelled before collision
+        Transform::UnitVector offset;
+    };
+
     /**
      * \brief Class used for all Collisions in the engine, it's a Polygon
      * containing n points
@@ -76,7 +89,12 @@ namespace obe::Collision
          * \param tagType List you want to clear (Tag / Accepted /Rejected)
          */
         void clearTags(ColliderTagType tagType);
-        [[nodiscard]] bool doesCollide(const Transform::UnitVector& offset) const;
+        /**
+         * \brief Checks if the collider is intersecting other colliders
+         * \param offset The offset to apply to the source collider
+         * \return std::vector of intersected colliders (empty if none found)
+         */
+        [[nodiscard]] std::vector<PolygonalCollider*> doesCollide(const Transform::UnitVector& offset) const;
         /**
          * \brief Checks if two polygons are intersecting
          * \param collider The other collider to test
@@ -123,10 +141,10 @@ namespace obe::Collision
          *        Colliders of the Scene
          * \param offset Distance the Collider should
          *        move to (if nothing collides)
-         * \return The maximum distance the
-         *         Collider can travel before colliding
+         * \return CollisionData struct containing the other colliders that had been
+         *         met and the maximum distance the collider can travel before colliding
          */
-        [[nodiscard]] Transform::UnitVector getMaximumDistanceBeforeCollision(
+        [[nodiscard]] CollisionData getMaximumDistanceBeforeCollision(
             const Transform::UnitVector& offset) const;
         /**
          * \brief Gets the Maximum distance before Collision with a specific

--- a/include/Core/Collision/Trajectory.hpp
+++ b/include/Core/Collision/Trajectory.hpp
@@ -14,7 +14,7 @@ namespace obe::Collision
     class PolygonalCollider;
 
     using OnCollideCallback
-        = std::function<void(Trajectory&, Transform::UnitVector, Transform::UnitVector)>;
+        = std::function<void(Trajectory&, Transform::UnitVector, Transform::UnitVector, std::vector<PolygonalCollider*>&)>;
     using TrajectoryCheckFunction
         = std::function<void(Trajectory&, Transform::UnitVector&, PolygonalCollider*)>;
 

--- a/src/Core/Bindings/Collision/Collision.cpp
+++ b/src/Core/Bindings/Collision/Collision.cpp
@@ -16,6 +16,14 @@ namespace obe::Collision::Bindings
                 { "Accepted", obe::Collision::ColliderTagType::Accepted },
                 { "Rejected", obe::Collision::ColliderTagType::Rejected } });
     }
+    void LoadStructCollisionData(sol::state_view state)
+    {
+        sol::table CollisionNamespace = state["obe"]["Collision"].get<sol::table>();
+        sol::usertype<obe::Collision::CollisionData> bindCollisionData
+            = CollisionNamespace.new_usertype<obe::Collision::CollisionData>("CollisionData");
+        bindCollisionData["colliders"] = &obe::Collision::CollisionData::colliders;
+        bindCollisionData["offset"] = &obe::Collision::CollisionData::offset;
+    }
     void LoadClassPolygonalCollider(sol::state_view state)
     {
         sol::table CollisionNamespace = state["obe"]["Collision"].get<sol::table>();
@@ -34,7 +42,7 @@ namespace obe::Collision::Bindings
         bindPolygonalCollider["clearTags"]
             = &obe::Collision::PolygonalCollider::clearTags;
         bindPolygonalCollider["doesCollide"]
-            = sol::overload(static_cast<bool (obe::Collision::PolygonalCollider::*)(
+            = sol::overload(static_cast<std::vector<PolygonalCollider*> (obe::Collision::PolygonalCollider::*)(
                                 const obe::Transform::UnitVector&) const>(
                                 &obe::Collision::PolygonalCollider::doesCollide),
                 static_cast<bool (obe::Collision::PolygonalCollider::*)(
@@ -48,7 +56,7 @@ namespace obe::Collision::Bindings
         bindPolygonalCollider["getAllTags"]
             = &obe::Collision::PolygonalCollider::getAllTags;
         bindPolygonalCollider["getMaximumDistanceBeforeCollision"] = sol::overload(
-            static_cast<obe::Transform::UnitVector (obe::Collision::PolygonalCollider::*)(
+            static_cast<CollisionData (obe::Collision::PolygonalCollider::*)(
                 const obe::Transform::UnitVector&) const>(
                 &obe::Collision::PolygonalCollider::getMaximumDistanceBeforeCollision),
             static_cast<obe::Transform::UnitVector (obe::Collision::PolygonalCollider::*)(

--- a/src/Core/Bindings/index.cpp
+++ b/src/Core/Bindings/index.cpp
@@ -168,8 +168,9 @@ namespace obe::Bindings
             .add("ClassTrajectory", &obe::Collision::Bindings::LoadClassTrajectory)
             .add(
                 "ClassTrajectoryNode", &obe::Collision::Bindings::LoadClassTrajectoryNode)
-            .add("EnumColliderTagType",
-                &obe::Collision::Bindings::LoadEnumColliderTagType);
+            .add(
+                "EnumColliderTagType", &obe::Collision::Bindings::LoadEnumColliderTagType)
+            .add("CollisionData", &obe::Collision::Bindings::LoadStructCollisionData);
 
         BindTree["obe"]["Component"].add(
             "ClassComponentBase", &obe::Component::Bindings::LoadClassComponentBase);

--- a/src/Core/Collision/PolygonalCollider.cpp
+++ b/src/Core/Collision/PolygonalCollider.cpp
@@ -80,10 +80,13 @@ namespace obe::Collision
     {
     }
 
-    Transform::UnitVector PolygonalCollider::getMaximumDistanceBeforeCollision(
+    CollisionData PolygonalCollider::getMaximumDistanceBeforeCollision(
         const Transform::UnitVector& offset) const
     {
         std::vector<Transform::UnitVector> limitedMaxDistances;
+        CollisionData collData;
+        collData.offset = offset;
+
         for (auto& collider : Pool)
         {
             if (checkTags(*collider))
@@ -96,6 +99,7 @@ namespace obe::Collision
                 if (maxDist != offset && collider != this)
                 {
                     limitedMaxDistances.push_back(maxDist);
+                    collData.colliders.push_back(collider);
                 }
             }
         }
@@ -115,9 +119,9 @@ namespace obe::Collision
                         = std::pair<double, Transform::UnitVector>(dist, distCoordinates);
                 }
             }
-            return minDist.second;
+            collData.offset = minDist.second;
         }
-        return offset;
+        return collData;
     }
 
     std::string PolygonalCollider::getParentId() const
@@ -145,20 +149,21 @@ namespace obe::Collision
         m_tags.at(tagType).clear();
     }
 
-    bool PolygonalCollider::doesCollide(const Transform::UnitVector& offset) const
+    std::vector<PolygonalCollider*> PolygonalCollider::doesCollide(const Transform::UnitVector& offset) const
     {
+        std::vector<PolygonalCollider*> touchedColliders;
         for (auto& collider : Pool)
         {
-            if (checkTags(*collider))
+            if (collider != this && checkTags(*collider))
             {
                 if (this->doesCollide(*collider, offset))
                 {
-                    return true;
+                    touchedColliders.push_back(collider);
                 }
             }
         }
 
-        return false;
+        return touchedColliders;
     }
 
     void PolygonalCollider::removeTag(ColliderTagType tagType, const std::string& tag)

--- a/src/Core/Collision/TrajectoryNode.cpp
+++ b/src/Core/Collision/TrajectoryNode.cpp
@@ -59,19 +59,20 @@ namespace obe::Collision
                     currentTrajectory->setSpeed(currentTrajectory->m_speed
                         + currentTrajectory->m_acceleration * dt);
                     baseOffset = getOffset(*currentTrajectory);
-                    Transform::UnitVector realOffset = baseOffset;
+                    obe::Collision::CollisionData collData;
+                    collData.offset = baseOffset;
                     if (m_probe != nullptr)
                     {
-                        realOffset
-                            = m_probe->getMaximumDistanceBeforeCollision(realOffset);
+                        collData
+                            = m_probe->getMaximumDistanceBeforeCollision(collData.offset);
                     }
                     auto onCollideCallback = trajectory.second->getOnCollideCallback();
-                    if (realOffset != baseOffset && onCollideCallback)
+                    if (collData.offset != baseOffset && onCollideCallback)
                     {
                         onCollideCallback(
-                            *trajectory.second.get(), baseOffset, realOffset);
+                            *trajectory.second.get(), baseOffset, collData.offset, collData.colliders);
                     }
-                    m_sceneNode.move(realOffset);
+                    m_sceneNode.move(collData.offset);
                 }
             }
         }


### PR DESCRIPTION
Added `CollisionData `struct, returned by `collider.getMaximumDistanceBeforeCollision`.
Now a vector of touched colliders is sent to `OnCollide` callback.
Now `collider.doesCollide()` return a vector of touched colliders.