### PR TITLE
Closes #293 : Put colliders in collisionData after max distance calculation

### DIFF
--- a/src/Core/Collision/PolygonalCollider.cpp
+++ b/src/Core/Collision/PolygonalCollider.cpp
@@ -84,6 +84,8 @@ namespace obe::Collision
         const Transform::UnitVector& offset) const
     {
         std::vector<Transform::UnitVector> limitedMaxDistances;
+        std::vector<std::pair<PolygonalCollider*, Transform::UnitVector>> collidersInOffset;
+
         CollisionData collData;
         collData.offset = offset;
 
@@ -99,7 +101,8 @@ namespace obe::Collision
                 if (maxDist != offset && collider != this)
                 {
                     limitedMaxDistances.push_back(maxDist);
-                    collData.colliders.push_back(collider);
+                    collidersInOffset.push_back(std::make_pair(collider, maxDist));
+                    //collData.colliders.push_back(collider);
                 }
             }
         }
@@ -120,6 +123,14 @@ namespace obe::Collision
                 }
             }
             collData.offset = minDist.second;
+
+            for (auto& inOffset : collidersInOffset)
+            {
+                if (inOffset.second == minDist.second)
+                {
+                    collData.colliders.push_back(inOffset.first);
+                }
+            }
         }
         return collData;
     }

--- a/src/Core/Collision/PolygonalCollider.cpp
+++ b/src/Core/Collision/PolygonalCollider.cpp
@@ -83,7 +83,6 @@ namespace obe::Collision
     CollisionData PolygonalCollider::getMaximumDistanceBeforeCollision(
         const Transform::UnitVector& offset) const
     {
-        std::vector<Transform::UnitVector> limitedMaxDistances;
         std::vector<std::pair<PolygonalCollider*, Transform::UnitVector>> collidersInOffset;
 
         CollisionData collData;
@@ -100,30 +99,27 @@ namespace obe::Collision
                 // maxDist.x, maxDist.y);
                 if (maxDist != offset && collider != this)
                 {
-                    limitedMaxDistances.push_back(maxDist);
                     collidersInOffset.push_back(std::make_pair(collider, maxDist));
-                    //collData.colliders.push_back(collider);
                 }
             }
         }
 
         const Transform::UnitVector destPos
             = (this->getCentroid() + offset).to<Transform::Units::ScenePixels>();
-        if (!limitedMaxDistances.empty())
+        if (!collidersInOffset.empty())
         {
             std::pair<double, Transform::UnitVector> minDist(-1, Transform::UnitVector());
-            for (Transform::UnitVector& distCoordinates : limitedMaxDistances)
-            {
-                double dist = std::sqrt(std::pow(distCoordinates.x - destPos.x, 2)
-                    + std::pow(distCoordinates.y - destPos.y, 2));
+            for (auto& inOffset : collidersInOffset) {
+                double dist = std::sqrt(std::pow(inOffset.second.x - destPos.x, 2)
+                    + std::pow(inOffset.second.y - destPos.y, 2));
                 if (minDist.first == -1 || minDist.first > dist)
                 {
-                    minDist
-                        = std::pair<double, Transform::UnitVector>(dist, distCoordinates);
+                    minDist = std::pair<double, Transform::UnitVector>(
+                        dist, inOffset.second);
                 }
             }
-            collData.offset = minDist.second;
 
+            collData.offset = minDist.second;
             for (auto& inOffset : collidersInOffset)
             {
                 if (inOffset.second == minDist.second)
@@ -132,6 +128,7 @@ namespace obe::Collision
                 }
             }
         }
+
         return collData;
     }
 

--- a/src/Core/Collision/PolygonalCollider.cpp
+++ b/src/Core/Collision/PolygonalCollider.cpp
@@ -83,7 +83,7 @@ namespace obe::Collision
     CollisionData PolygonalCollider::getMaximumDistanceBeforeCollision(
         const Transform::UnitVector& offset) const
     {
-        std::vector<std::pair<PolygonalCollider*, Transform::UnitVector>> collidersInOffset;
+        std::vector<std::pair<PolygonalCollider*, Transform::UnitVector>> reachableColliders;
 
         CollisionData collData;
         collData.offset = offset;
@@ -99,32 +99,32 @@ namespace obe::Collision
                 // maxDist.x, maxDist.y);
                 if (maxDist != offset && collider != this)
                 {
-                    collidersInOffset.push_back(std::make_pair(collider, maxDist));
+                    reachableColliders.emplace_back(collider, maxDist);
                 }
             }
         }
 
         const Transform::UnitVector destPos
             = (this->getCentroid() + offset).to<Transform::Units::ScenePixels>();
-        if (!collidersInOffset.empty())
+        if (!reachableColliders.empty())
         {
             std::pair<double, Transform::UnitVector> minDist(-1, Transform::UnitVector());
-            for (auto& inOffset : collidersInOffset) {
-                double dist = std::sqrt(std::pow(inOffset.second.x - destPos.x, 2)
-                    + std::pow(inOffset.second.y - destPos.y, 2));
+            for (auto& reachable : reachableColliders) {
+                double dist = std::sqrt(std::pow(reachable.second.x - destPos.x, 2)
+                    + std::pow(reachable.second.y - destPos.y, 2));
                 if (minDist.first == -1 || minDist.first > dist)
                 {
                     minDist = std::pair<double, Transform::UnitVector>(
-                        dist, inOffset.second);
+                        dist, reachable.second);
                 }
             }
 
             collData.offset = minDist.second;
-            for (auto& inOffset : collidersInOffset)
+            for (auto& reachable : reachableColliders)
             {
-                if (inOffset.second == minDist.second)
+                if (reachable.second == minDist.second)
                 {
-                    collData.colliders.push_back(inOffset.first);
+                    collData.colliders.push_back(reachable.first);
                 }
             }
         }


### PR DESCRIPTION
In PolygonalCollider::getMaximumDistanceBeforeCollision, ColliderData.offset contains the computed max distance, but ColliderData.colliders contains the colliders that had been got BEFORE the maximum distance calculation. In other words, the colliders returned can be reached individually, without taking the other colliders into account.