### PR TITLE
TrajectoryNode: move SceneNode before calling collision callback function

### DIFF
--- a/src/Core/Collision/TrajectoryNode.cpp
+++ b/src/Core/Collision/TrajectoryNode.cpp
@@ -66,13 +66,13 @@ namespace obe::Collision
                         collData
                             = m_probe->getMaximumDistanceBeforeCollision(collData.offset);
                     }
+                    m_sceneNode.move(collData.offset);
                     auto onCollideCallback = trajectory.second->getOnCollideCallback();
                     if (collData.offset != baseOffset && onCollideCallback)
                     {
                         onCollideCallback(
                             *trajectory.second.get(), baseOffset, collData);
                     }
-                    m_sceneNode.move(collData.offset);
                 }
             }
         }


### PR DESCRIPTION
SceneNode is now moved before the collision callback is called. So in the callback, we get the coordinates of the SceneNode at the moment of the collision, instead of the coordinates before the collision.