### PR TITLE
Fix tunnelling on collision detection (closes #308)

### DIFF
--- a/include/Core/Transform/UnitVector.hpp
+++ b/include/Core/Transform/UnitVector.hpp
@@ -260,6 +260,10 @@ namespace obe::Transform
         [[nodiscard]] UnitVector rotate(
             double angle, UnitVector zero = UnitVector(0, 0)) const;
         [[nodiscard]] double distance(const UnitVector& vec) const;
+        /**
+         * \brief Return the length of the UnitVector
+         */
+        [[nodiscard]] double magnitude() const;
     };
 
     template <> inline UnitVector UnitVector::to<Units::ViewPercentage>() const

--- a/src/Core/Bindings/index.cpp
+++ b/src/Core/Bindings/index.cpp
@@ -237,6 +237,7 @@ namespace obe::Bindings
         obe::Scene::Bindings::LoadClassSceneNode(state);
         obe::Scene::Bindings::LoadFunctionSceneGetGameObjectProxy(state);
         obe::Scene::Bindings::LoadFunctionSceneCreateGameObjectProxy(state);
+        obe::Scene::Bindings::LoadFunctionSceneGetAllGameObjectsProxy(state);
 
         obe::Scene::Exceptions::Bindings::LoadClassChildNotInSceneNode(state);
         obe::Scene::Exceptions::Bindings::LoadClassGameObjectAlreadyExists(state);

--- a/src/Core/Bindings/obe/Transform/Transform.cpp
+++ b/src/Core/Bindings/obe/Transform/Transform.cpp
@@ -337,6 +337,7 @@ namespace obe::Transform::Bindings
                 return self->rotate(angle, zero);
             });
         bindUnitVector["distance"] = &obe::Transform::UnitVector::distance;
+        bindUnitVector["magnitude"] = &obe::Transform::UnitVector::magnitude;
         bindUnitVector["x"] = &obe::Transform::UnitVector::x;
         bindUnitVector["y"] = &obe::Transform::UnitVector::y;
         bindUnitVector["unit"] = &obe::Transform::UnitVector::unit;

--- a/src/Core/Collision/PolygonalCollider.cpp
+++ b/src/Core/Collision/PolygonalCollider.cpp
@@ -106,7 +106,7 @@ namespace obe::Collision
 
         if (!reachableColliders.empty())
         {
-            // Get lowest distance between this collider and a reachable collider
+            // Get lowest offset between this collider and a reachable collider
             for (auto& reachable : reachableColliders)
             {
                 if (reachable.second.magnitude() < collData.offset.to(Transform::Units::ScenePixels).magnitude())
@@ -115,7 +115,7 @@ namespace obe::Collision
                 }
             }
 
-            // Get touched colliders (=> in range of lowest distance)
+            // Get touched colliders (=> in range of lowest offset)
             for (auto& reachable : reachableColliders)
             {
                 if (reachable.second == collData.offset)

--- a/src/Core/Collision/PolygonalCollider.cpp
+++ b/src/Core/Collision/PolygonalCollider.cpp
@@ -104,25 +104,21 @@ namespace obe::Collision
             }
         }
 
-        const Transform::UnitVector destPos
-            = (this->getCentroid() + offset).to<Transform::Units::ScenePixels>();
         if (!reachableColliders.empty())
         {
-            std::pair<double, Transform::UnitVector> minDist(-1, Transform::UnitVector());
-            for (auto& reachable : reachableColliders) {
-                double dist = std::sqrt(std::pow(reachable.second.x - destPos.x, 2)
-                    + std::pow(reachable.second.y - destPos.y, 2));
-                if (minDist.first == -1 || minDist.first > dist)
+            // Get lowest distance between this collider and a reachable collider
+            for (auto& reachable : reachableColliders)
+            {
+                if (reachable.second.magnitude() < collData.offset.to(Transform::Units::ScenePixels).magnitude())
                 {
-                    minDist = std::pair<double, Transform::UnitVector>(
-                        dist, reachable.second);
+                    collData.offset = reachable.second;
                 }
             }
 
-            collData.offset = minDist.second;
+            // Get touched colliders (=> in range of lowest distance)
             for (auto& reachable : reachableColliders)
             {
-                if (reachable.second == minDist.second)
+                if (reachable.second == collData.offset)
                 {
                     collData.colliders.push_back(reachable.first);
                 }

--- a/src/Core/Transform/UnitVector.cpp
+++ b/src/Core/Transform/UnitVector.cpp
@@ -303,4 +303,8 @@ namespace obe::Transform
     {
         return std::sqrt(std::pow(x - vec.x, 2) + std::pow(y - vec.y, 2));
     }
+    double UnitVector::magnitude() const
+    {
+        return std::sqrt(std::pow(x, 2) + std::pow(y, 2));
+    }
 } // namespace obe::Transform


### PR DESCRIPTION
Full speed ahead, no more tunneling :
![image](https://user-images.githubusercontent.com/4027974/94969232-a3233880-0502-11eb-936c-51aa62925b95.png)

Added magnitude function to UnitVector.

(+ added missing binding for getAllGameObjects proxy)