### PR TITLE
Reduce compile time through PCH and parallel builds

### DIFF
--- a/include/Core/PreCompileHeader.hpp
+++ b/include/Core/PreCompileHeader.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <bitset>
+#include <chrono>
+#include <exception>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <SFML/Audio.hpp>
+#include <SFML/Graphics.hpp>
+#include <sol/sol.hpp>
+#include <spdlog/spdlog.h>
+#include <vili/node.hpp>

--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -5,9 +5,12 @@ include(group_files)
 file(GLOB_RECURSE OBE_HEADERS
     ${ObEngine_SOURCE_DIR}/include/Core/*.hpp
     ${ObEngine_SOURCE_DIR}/include/Core/*.inl)
+list(REMOVE_ITEM OBE_HEADERS "${ObEngine_SOURCE_DIR}/include/Core/PreCompileHeader.hpp")
 file(GLOB_RECURSE OBE_SOURCES ${ObEngine_SOURCE_DIR}/src/Core/*.cpp)
 
 add_library(ObEngineCore ${OBE_HEADERS} ${OBE_SOURCES})
+
+target_precompile_headers(ObEngineCore PRIVATE ${ObEngine_SOURCE_DIR}/include/Core/PreCompileHeader.hpp)
 
 if (${BUILD_PLAYER} OR ${BUILD_DEV})
     target_compile_definitions(ObEngineCore PUBLIC OBE_IS_NOT_PLUGIN)
@@ -52,7 +55,9 @@ set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_EXTENSIONS OFF)
 
 if (MSVC)
     if (NOT (MSVC_VERSION LESS 1920))
-        target_compile_options(ObEngineCore PRIVATE /permissive- /bigobj)
+        target_compile_options(ObEngineCore PRIVATE /permissive- /bigobj /MP)
+    else()
+        target_compile_options(ObEngineCore PRIVATE /MP)
     endif()
 endif()
 


### PR DESCRIPTION
- A Pre Compile Header (PCH) will put all the common and rarely changing headers into one compilation unit, that is added to every source file, thus making it unnecessary for the compiler to rebuild those header files.
- The `/MP` flag allows for parallel builds in Visual Studio. I'm not 100% certain if this really does anything and for CIs it's probably pointless.

## Resources

- https://onqtam.com/programming/2019-12-20-pch-unity-cmake-3-16/
- https://devblogs.microsoft.com/cppblog/introducing-vcperf-timetrace-for-cpp-build-time-analysis/
- https://medium.com/@unicorn_dev/speeding-up-the-build-of-c-and-c-projects-453ce85dd0e1