### PR TITLE
Minor fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@
 *And by the way, it is pronounced* | ˈɒb ˈendʒɪn |, *the umlaut on the Ö is just there because it looks like a surprised face, it doesn't influence the pronounciation.*
 
 ## How do I build it ?
-You will need SFML :
-- [SFML 2.5.1](https://www.sfml-dev.org/download/sfml/2.5.1/index-fr.php) (Display, Input, Network, Sound and much more)
+- You will need [SFML 2.5.1](https://www.sfml-dev.org/download/sfml/2.5.1/index-fr.php) (Display, Input, Network, Sound and much more)
+
+- You may also need alsa-lib (if you're on Linux)
 
 There are other third-party libraries but they are included in the repository (`extlibs/` folder).
 Check this tutorial to learn how to build ÖbEngine : [Building ÖbEngine](https://github.com/Sygmei/ObEngine/wiki/Building-ObEngine)

--- a/include/Core/Graphics/Color.hpp
+++ b/include/Core/Graphics/Color.hpp
@@ -21,7 +21,6 @@ namespace obe::Graphics
         Color();
         Color(double r, double g, double b, double a = 255);
         explicit Color(const std::string& nameOrHex);
-        Color(const Color& color);
         Color(const sf::Color& color);
 
         void fromString(std::string string);

--- a/include/Core/Transform/Referential.hpp
+++ b/include/Core/Transform/Referential.hpp
@@ -29,7 +29,6 @@ namespace obe::Transform
     public:
         Referential();
         Referential(double refX, double refY);
-        Referential(const Referential& ref);
 
         bool operator==(const Referential& ref) const;
         bool operator!=(const Referential& ref) const;

--- a/src/Core/Animation/Easing.cpp
+++ b/src/Core/Animation/Easing.cpp
@@ -51,12 +51,13 @@ namespace obe::Animation::Easing
 
     double OutCubic(double t)
     {
-        return 1 + (--t) * t * t;
+        --t;
+        return 1 + t * t * t;
     }
 
     double InOutCubic(double t)
     {
-        return t < 0.5 ? 4 * t * t * t : 1 + (--t) * (2 * (--t)) * (2 * t);
+        return t < 0.5 ? 4 * t * t * t : 1 + 4 * (t-2) * (t-2) * (t-2);
     }
 
     double InQuart(double t)
@@ -67,7 +68,8 @@ namespace obe::Animation::Easing
 
     double OutQuart(double t)
     {
-        t = (--t) * t;
+        --t;
+        t = t * t;
         return 1 - t * t;
     }
 
@@ -80,7 +82,8 @@ namespace obe::Animation::Easing
         }
         else
         {
-            t = (--t) * t;
+            --t;
+            t = t * t;
             return 1 - 8 * t * t;
         }
     }
@@ -93,7 +96,8 @@ namespace obe::Animation::Easing
 
     double OutQuint(double t)
     {
-        double t2 = (--t) * t;
+        --t;
+        double t2 = t * t;
         return 1 + t * t2 * t2;
     }
 
@@ -107,7 +111,8 @@ namespace obe::Animation::Easing
         }
         else
         {
-            t2 = (--t) * t;
+            --t;
+            t2 = t * t;
             return 1 + 16 * t * t2 * t2;
         }
     }
@@ -163,7 +168,8 @@ namespace obe::Animation::Easing
 
     double OutBack(double t)
     {
-        return 1 + (--t) * t * (2.70158 * t + 1.70158);
+        --t;
+        return 1 + t * t * (2.70158 * t + 1.70158);
     }
 
     double InOutBack(double t)
@@ -174,7 +180,8 @@ namespace obe::Animation::Easing
         }
         else
         {
-            return 1 + (--t) * t * 2 * (7 * t + 2.5);
+            --t;
+            return 1 + t * t * 2 * (7 * t + 2.5);
         }
     }
 

--- a/src/Core/Graphics/Color.cpp
+++ b/src/Core/Graphics/Color.cpp
@@ -245,13 +245,6 @@ namespace obe::Graphics
         this->fromString(nameOrHex);
     }
 
-    Color::Color(const Color& color)
-    {
-        r = color.r;
-        g = color.g;
-        b = color.b;
-        a = color.a;
-    }
 
     Color::Color(const sf::Color& color)
     {

--- a/src/Core/Transform/Referential.cpp
+++ b/src/Core/Transform/Referential.cpp
@@ -38,11 +38,6 @@ namespace obe::Transform
         assert(refY >= -1 && refY <= 1);
     }
 
-    Referential::Referential(const Referential& ref)
-    {
-        m_refX = ref.m_refX;
-        m_refY = ref.m_refY;
-    }
 
     bool Referential::operator==(const Referential& ref) const
     {


### PR DESCRIPTION
Just some small edits.

- README was updated. The alsa-lib-devel package is needed to build this on Fedora 33.
- The unsequenced operations were undefined behaviour, so they were replaced with well-defined equivalents.
- Some unnecessary copy constructors were removed since they are implicitly defined by default and explicitly declaring them removed the move constructor & move assignment operators.